### PR TITLE
Fail build if dependencies aren't found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,4 +33,25 @@ ign_find_package(ignition-tools REQUIRED)
 ign_find_package(ignition-transport9 REQUIRED)
 ign_find_package(sdformat10 REQUIRED)
 
+if(build_warnings)
+  set(all_warnings " CONFIGURATION WARNINGS:")
+  foreach (msg ${build_warnings})
+    ign_string_append(all_warnings " -- ${msg}" DELIM "\n")
+  endforeach ()
+  message(WARNING "${all_warnings}")
+endif (build_warnings)
+
+if(build_errors)
+  message(SEND_ERROR "-- BUILD ERRORS: These must be resolved before compiling.")
+  foreach(msg ${build_errors})
+    message(SEND_ERROR "-- ${msg}")
+  endforeach()
+  message(SEND_ERROR "-- END BUILD ERRORS\n")
+
+  set(error_str "Errors encountered in build. Please see BUILD ERRORS above.")
+
+  message(FATAL_ERROR "${error_str}")
+
+endif()
+
 install(DIRECTORY gazebodistro DESTINATION ${IGN_DATA_INSTALL_DIR})


### PR DESCRIPTION
Follow up to #5. Without this, the build won't fail if required dependencies are missing. 

`ign-cmake` usually handles this with `ign_configure_build(QUIT_IF_BUILD_ERRORS)`, but we can't use that here because this package doesn't have source code. So I just copied the part of `ign-cmake` that handles the errors instead,